### PR TITLE
Documenting how to use OnlyKey with OpenSSH 8.2+

### DIFF
--- a/pages/mydoc/features.md
+++ b/pages/mydoc/features.md
@@ -143,7 +143,11 @@ Keys are loaded using the OnlyKey App. Step by step directions for generating an
 
 ### SSH Login {#ssh-login}
 
-SSH Authentication - Currently only ECC keys (curve25519 & NIST-P256) are supported for SSH authentication. Using the [OnlyKey-Agent](https://docs.crp.to/onlykey-agent.html) SSH authentication is easy and your private key is never exposed on a computer where it can be compromised by hacker.
+OnlyKey can be used for SSH Authentication in two ways:
+
+1. Using the [OnlyKey-Agent](https://docs.crp.to/onlykey-agent.html), SSH authentication is easy and your private key is never exposed on a computer where it can be compromised by hacker. Currently only ECC keys (curve25519 & NIST-P256) are supported for SSH authentication.
+
+2. Using [OpenSSH](https://docs.crp.to/openssh.html) version [8.2 or higher](http://www.openssh.com/txt/release-8.2), OnlyKey can be paired with a traditional SSH key for second factor authentication.  Currently only ecdsa is supported.
 
 ### OpenPGP Everywhere Message and File Encryption {#openpgp}
 

--- a/pages/mydoc/openssh.md
+++ b/pages/mydoc/openssh.md
@@ -1,0 +1,91 @@
+---
+title: OpenSSH
+tags: [SSH]
+keywords: OnlyKey, SSH, OpenSSH
+last_updated: May, 22, 2020
+summary: The OnlyKey can be used with OpenSSH to provide multifactor authentication on SSH keys
+sidebar: mydoc_sidebar
+permalink: openssh.html
+folder: mydoc
+---
+
+# OpenSSH v8.2
+
+This document describes how to use the OnlyKey as a second factor authentication device with traditional SSH Keys.
+
+The OnlyKey currently only supports `ecdsa` keys with OpenSSH.
+
+## Quickstart Guide
+
+1. You must have OpenSSH v8.2 or higher and the necessary [prerequisites](#prerequisites) installed.
+
+2. You may now generate your SSH keys using `ssh-keygen`.  Provide any desired optional arguments and you will be prompted to press your OnlyKey and provide an optional passphrase.
+
+```
+$ ssh-keygen -t ecdsa-sk
+You may need to touch your authenticator to authorize key generation.
+Enter file in which to save the key (/home/user/.ssh/id_ecdsa_sk):
+Enter passphrase (empty for no passphrase):
+Enter same passphrase again:
+Your identification has been saved in /home/user/.ssh/id_ecdsa_sk
+Your public key has been saved in /home/user/.ssh/id_ecdsa_sk.pub
+The key fingerprint is:
+SHA256:ECFmaoLZENpq0rLem8HC1F6vTwH1pjsnR6X8l/r54rQ user@host
+The key's randomart image is:
++-[ECDSA-SK 256]--+
+|o.  + oo         |
+|o= + ....        |
+|= =. ... o .     |
+| =.   ..+ o      |
+|+o.. . oS+       |
+|=oo . . + .   .  |
+|.o +   * o . +   |
+|. o o o o = +.o  |
+| . +....   .oEo. |
++----[SHA256]-----+
+```
+
+3. Then copy the new public key to your remote hosts.
+
+```
+$ ssh-copy-id -i ~/.ssh/id_ecdsa_sk user@remotehost
+/usr/bin/ssh-copy-id: INFO: Source of key(s) to be installed: "id_ecdsa_sk.pub"
+/usr/bin/ssh-copy-id: INFO: attempting to log in with the new key(s), to filter out any that are already installed
+/usr/bin/ssh-copy-id: INFO: 1 key(s) remain to be installed -- if you are prompted now it is to install the new keys
+
+Number of key(s) added: 1
+
+Now try logging into the machine, with:   "ssh 'user@remotehost'"
+and check to make sure that only the key(s) you wanted were added.
+```
+
+4. And then log in your remote host.  You will be prompted to enter your passphrase (if entered during key generation) and asked to press your OnlyKey.
+
+```
+$ ssh -i ~/.ssh/id_ecdsa_sk user@remotehost
+Enter passphrase for key 'id_ecdsa_sk':
+Confirm user presence for key ECDSA-SK SHA256:ECFmaoLZENpq0rLem8HC1F6vTwH1pjsnR6X8l/r54rQ
+```
+
+5. Success!
+
+
+## Prerequisites
+
+### Void Linux
+```
+$ xbps-install -S openssh openssh-sk-helper
+```
+
+
+### Arch Linux
+```
+$ pacman -S openssh libfido2
+```
+
+### Ubuntu (20.10 Groovy Gorilla) & Debian (bullseye)
+```
+$ apt install openssh-client
+```
+
+


### PR DESCRIPTION
I didn't see a PR submission style guide, please forgive me if this is way out of line.

With this PR, I hope to expand on the  perceived usability of OnlyKey by drawing attention to its usefulness with OpenSSH.

Although not unique to OnlyKey, all (most?) FIDO2 keys can be used with OpenSSH and it should be known that OnlyKey is not excluded - not to supersede the awesome onlykey-agent, but only as an alternative.

I've tried to make the instructions as clear and easy to read as possible, but no doubt can be improved.   Please feel free to edit as you see fit, to meet your style conventions and level of quality.

A couple notes:
1. FIDO2 support in OpenSSH is relatively new and most Linux distributions are lagging at adoption.  Therefore, I have included instructions for the *next* version of Ubuntu and Debian.  I am only guessing with the requirements.   Likewise with Arch - I no longer have an instance of Arch to prove out the prerequisites.  Based on [this bug report](https://bugs.archlinux.org/task/65513), what is provided *should* be sufficient.  I will fire up a VM one of these days and prove it out.  Feel free to hold up this PR until then, if you desire.
2. I do not have access to Windows or Mac machines and cannot provide instructions on those platforms.

Also, an aside, I have tried to emphasize that only `ecdsa` keys are currently supported.  Your FIDO2 implementation comes from SoloKeys, if I'm not mistaken.  Their implementation of `ed25519` is a WIP.  It would be great to have ed25519 support in OnlyKey's FIDO2 - either pulled from upstream when Solo finishes their work, or you guys squeeze your own (already working) ed25519 implementation into FIDO2.

Anyway, thanks, and enjoy!
