### PR TITLE
TREZOR → OnlyKey

### DIFF
--- a/pages/mydoc/onlykey-agent.md
+++ b/pages/mydoc/onlykey-agent.md
@@ -149,7 +149,7 @@ Password managers such as [pass](https://www.passwordstore.org/) and [gopass](ht
 
 ##### With `pass`:
 
-First install `pass` from [passwordstore.org] and initialize it to use your TREZOR-based GPG identity:
+First install `pass` from [passwordstore.org] and initialize it to use your OnlyKey-based GPG identity:
 ```
 $ pass init "Bob Smith <bob@protonmail.com>"
 Password store initialized for Bob Smith <bob@protonmail.com>


### PR DESCRIPTION
Your tool might be a fork of a more generic tool that also supports TREZOR (and originated for that security device if I'm not mistaken), but on the official OnlyKey site, the phrasing "your TREZOR-based GPG identity" looks strange.  Note that I've no idea if the original source's license permits this documentation change?